### PR TITLE
Use a newer node version for Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - "8"
+  - "stable"
 
 cache:
   directories:


### PR DESCRIPTION
0afe10c34b1834a0834bb9d7a0fc2ed4426e25f9 and our old node version on Travis-CI is making CI fail.

https://travis-ci.com/freeboardgame/FreeBoardGame.org/builds/99573941

CI passes with the newer node version.