### PR TITLE
Remove robots.txt while building Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,5 +21,7 @@ RUN yarn install
 RUN yarn run hexo generate
 
 WORKDIR /appdata
+# remove robots.txt
+RUN rm static/robots.txt
 # start server
 CMD ["yarn", "run", "server"]

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,2 +1,2 @@
 User-agent: *
-Disallow:
+Disallow: /


### PR DESCRIPTION
Remove robots.txt while building our Docker image.  This way, yarn run dev will have a /robots.txt that disallows crawling, but our production docker images will not. 