### PR TITLE
Remove target="_blank" from Go Home button so home doesn't open in a new window.

### DIFF
--- a/src/App/MessagePageClass.tsx
+++ b/src/App/MessagePageClass.tsx
@@ -55,7 +55,7 @@ export class MessagePage extends React.Component<IMessageProps, IMessageState> {
     }
     if (!this.state.linkHidden) {
       linkHome = (
-        <Button href="/" target="_blank" variant="outlined" style={{ margin: '8px' }}>
+        <Button href="/" variant="outlined" style={{ margin: '8px' }}>
           <HomeIcon style={{ marginRight: '8px' }} />
           Go Home
         </Button>);


### PR DESCRIPTION
Remove target="_blank" from Go Home button so home doesn't open in a new window.