### PR TITLE
Add easy AI to TicTacToe

### DIFF
--- a/src/App/Game/GameModePicker.test.tsx
+++ b/src/App/Game/GameModePicker.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { GameModePicker, GameMode, IGameModeInfo } from './GameModePicker';
+import { IGameModeExtraInfoSlider, IGameModeExtraInfoDropdown } from './GameModePicker';
 import ListItem from '@material-ui/core/ListItem';
 import { mount } from 'enzyme';
 import { expect } from 'chai';
@@ -21,4 +22,63 @@ describe('Game Mode Picker', () => {
     ));
     expect(wrapper.find('a').length).to.equal(3);
   });
+
+  it('should show a slider', () => {
+    const historyMock = { push: jest.fn() };
+    const modesMock: IGameModeInfo[] = [
+      {
+        mode: GameMode.AI,
+        cardDescription: 'foo AI',
+        extraInfo: { type: 'slider', min: 1, max: 8 } as IGameModeExtraInfoSlider,
+      },
+    ];
+    const wrapper = mount((
+      <MemoryRouter>
+        <GameModePicker gameCode="foo" modes={modesMock} />
+      </MemoryRouter>
+    ));
+    expect(wrapper.find('Slider').length).to.equal(1);
+  });
+
+  it('should show a dropdown', () => {
+    const wrapper = makeDropdownWrapper();
+    expect(wrapper.find('MenuList').length).to.equal(1);
+    expect(wrapper.find('MenuItem').length).to.equal(2);
+  });
+
+  it('should have the correct dropdown defaults', () => {
+    const wrapper = makeDropdownWrapper();
+    const easy = wrapper.find('MenuItem').at(0);
+    expect(easy.prop('value')).to.equal('Easy');
+    expect(easy.prop('selected')).to.equal(true);  // Easy is selected by default
+
+    const hard = wrapper.find('MenuItem').at(1);
+    expect(hard.prop('value')).to.equal('Hard');
+
+    expect(hard.prop('selected')).to.equal(false);  // Hard is deselected by default
+  });
+
+  it('it should be a functional dropdown', () => {
+    const wrapper = makeDropdownWrapper();
+    const hard = wrapper.find('MenuItem').at(1);
+    expect(hard.html()).not.to.contain('selected');
+    hard.simulate('click');
+    expect(hard.html()).to.contain('selected');
+  });
 });
+
+function makeDropdownWrapper() {
+  const modesMock: IGameModeInfo[] = [
+    {
+      mode: GameMode.AI,
+      cardDescription: 'foo AI',
+      extraInfo: { type: 'dropdown', options: ['Easy', 'Hard'] } as IGameModeExtraInfoDropdown,
+    },
+  ];
+  const wrapper = mount((
+    <MemoryRouter>
+      <GameModePicker gameCode="foo" modes={modesMock} />
+    </MemoryRouter>
+  ));
+  return wrapper;
+}

--- a/src/App/Game/GameModePicker.tsx
+++ b/src/App/Game/GameModePicker.tsx
@@ -7,6 +7,8 @@ import CardActions from '@material-ui/core/CardActions';
 import CardContent from '@material-ui/core/CardContent';
 import CardHeader from '@material-ui/core/CardHeader';
 import Slider from '@material-ui/lab/Slider';
+import MenuItem from '@material-ui/core/MenuItem';
+import MenuList from '@material-ui/core/MenuList';
 import Avatar from '@material-ui/core/Avatar';
 import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
@@ -39,6 +41,11 @@ export interface IGameModeExtraInfoSlider extends IGameModeExtraInfo {
   max: number;
 }
 
+export interface IGameModeExtraInfoDropdown extends IGameModeExtraInfo {
+  type: 'dropdown';
+  options: string[];
+}
+
 export enum GameMode {
   AI = 'AI',
   OnlineFriend = 'online',
@@ -51,7 +58,8 @@ export class GameModePicker extends React.Component<IGameModePickerProps, IGameM
     return React.createElement(Link, { ...props, to }, props.children);
   }
 
-  _handleExtraInfoChange = (mode: GameMode) => (event: any, value: number) => {
+  _handleExtraInfoChange = (mode: GameMode, argValue?: any) => (event: any, value?: number) => {
+    value = value || argValue;
     const newState: IGameModePickerState = {
       ...this.state,
       extraInfo: {
@@ -144,10 +152,36 @@ export class GameModePicker extends React.Component<IGameModePickerProps, IGameM
             />
           </div>
         );
+      } else if (extraInfo.type === 'dropdown') {
+        const dropdown = (extraInfo as IGameModeExtraInfoDropdown);
+        const list: any = [];  // TODO typing?
+        dropdown.options.map(option => {
+          list.push(
+            <MenuItem
+              onClick={this._handleExtraInfoChange(info.mode, option)}
+              value={option}
+              selected={(this.state.extraInfo as any)[info.mode] === option}
+            >
+              {option}
+            </MenuItem>);
+        });
+        return (
+          <div style={{ marginTop: '16px' }}>
+            <Typography id="label" style={{ marginBottom: '8px' }}>
+              <MenuList>
+                {list}
+              </MenuList>
+            </Typography>
+          </div>
+        );
       }
     }
     return null;
   }
+
+  // _handleDropdownClick = (option: string) => (event: React.MouseEvent<HTMLElement>) => {
+  // this.state = { ...this.state, dropdownSelecto
+  // }
 
   _getExtraInfoValue(info: IGameModeInfo): number {
     return (this.state.extraInfo as any)[info.mode] || 1;

--- a/src/App/Game/GameModePicker.tsx
+++ b/src/App/Game/GameModePicker.tsx
@@ -159,6 +159,7 @@ export class GameModePicker extends React.Component<IGameModePickerProps, IGameM
           list.push(
             <MenuItem
               onClick={this._handleExtraInfoChange(info.mode, option)}
+              key={option}
               value={option}
               selected={(this.state.extraInfo as any)[info.mode] === option}
             >
@@ -167,21 +168,21 @@ export class GameModePicker extends React.Component<IGameModePickerProps, IGameM
         });
         return (
           <div style={{ marginTop: '16px' }}>
-            <Typography id="label" style={{ marginBottom: '8px' }}>
-              <MenuList>
-                {list}
-              </MenuList>
-            </Typography>
+            <MenuList
+              style={{
+                paddingRight: '20%',
+                display: 'flex',
+                listStyle: 'none'
+              }}
+            >
+              {list}
+            </MenuList>
           </div>
         );
       }
     }
     return null;
   }
-
-  // _handleDropdownClick = (option: string) => (event: React.MouseEvent<HTMLElement>) => {
-  // this.state = { ...this.state, dropdownSelecto
-  // }
 
   _getExtraInfoValue(info: IGameModeInfo): number {
     return (this.state.extraInfo as any)[info.mode] || 1;

--- a/src/App/Game/GameModePicker.tsx
+++ b/src/App/Game/GameModePicker.tsx
@@ -154,10 +154,9 @@ export class GameModePicker extends React.Component<IGameModePickerProps, IGameM
         );
       } else if (extraInfo.type === 'dropdown') {
         const dropdown = (extraInfo as IGameModeExtraInfoDropdown);
-        const list: JSX.Element[] = [];
-        dropdown.options.map((option, idx) => {
+        const list: JSX.Element[] = dropdown.options.map((option, idx) => {
           idx++;
-          list.push(
+          return (
             <MenuItem
               onClick={this._handleExtraInfoChange(info.mode, idx)}
               key={option}

--- a/src/App/Game/GameModePicker.tsx
+++ b/src/App/Game/GameModePicker.tsx
@@ -58,8 +58,18 @@ export class GameModePicker extends React.Component<IGameModePickerProps, IGameM
     return React.createElement(Link, { ...props, to }, props.children);
   }
 
-  _handleExtraInfoChange = (mode: GameMode, argValue?: any) => (event: any, value?: number) => {
-    value = value || argValue;
+  _handleSliderChange = (mode: GameMode) => (event: any, value: number) => {
+    const newState: IGameModePickerState = {
+      ...this.state,
+      extraInfo: {
+        ...this.state.extraInfo,
+      },
+    };
+    newState.extraInfo[mode] = value;
+    this.setState(newState);
+  }
+
+  _handleClickSelection = (mode: GameMode, value: any) => (event: any) => {
     const newState: IGameModePickerState = {
       ...this.state,
       extraInfo: {
@@ -148,7 +158,7 @@ export class GameModePicker extends React.Component<IGameModePickerProps, IGameM
               min={slider.min}
               max={slider.max}
               step={1}
-              onChange={this._handleExtraInfoChange(info.mode)}
+              onChange={this._handleSliderChange(info.mode)}
             />
           </div>
         );
@@ -158,7 +168,7 @@ export class GameModePicker extends React.Component<IGameModePickerProps, IGameM
           idx++;
           return (
             <MenuItem
-              onClick={this._handleExtraInfoChange(info.mode, idx)}
+              onClick={this._handleClickSelection(info.mode, idx)}
               key={option}
               value={option}
               selected={this._getExtraInfoValue(info) === idx}

--- a/src/App/Game/GameModePicker.tsx
+++ b/src/App/Game/GameModePicker.tsx
@@ -172,7 +172,7 @@ export class GameModePicker extends React.Component<IGameModePickerProps, IGameM
               style={{
                 paddingRight: '20%',
                 display: 'flex',
-                listStyle: 'none'
+                listStyle: 'none',
               }}
             >
               {list}

--- a/src/App/Game/GameModePicker.tsx
+++ b/src/App/Game/GameModePicker.tsx
@@ -154,14 +154,15 @@ export class GameModePicker extends React.Component<IGameModePickerProps, IGameM
         );
       } else if (extraInfo.type === 'dropdown') {
         const dropdown = (extraInfo as IGameModeExtraInfoDropdown);
-        const list: any = [];  // TODO typing?
-        dropdown.options.map(option => {
+        const list: JSX.Element[] = [];
+        dropdown.options.map((option, idx) => {
+          idx++;
           list.push(
             <MenuItem
-              onClick={this._handleExtraInfoChange(info.mode, option)}
+              onClick={this._handleExtraInfoChange(info.mode, idx)}
               key={option}
               value={option}
-              selected={(this.state.extraInfo as any)[info.mode] === option}
+              selected={this._getExtraInfoValue(info) === idx}
             >
               {option}
             </MenuItem>);

--- a/src/games/index.tsx
+++ b/src/games/index.tsx
@@ -1,4 +1,5 @@
-import { IGameModeInfo, GameMode, IGameModeExtraInfoSlider } from '../App/Game/GameModePicker';
+import { IGameModeInfo, GameMode } from '../App/Game/GameModePicker';
+import { IGameModeExtraInfoSlider, IGameModeExtraInfoDropdown } from '../App/Game/GameModePicker';
 import SeabattleThumbnail from './seabattle/media/thumbnail.png';
 import ChessThumbnail from './chess/media/thumbnail.png';
 import TicTacToeThumbnail from './tictactoe/media/thumbnail.png';
@@ -78,6 +79,7 @@ export const GAMES_MAP: IGameDefMap = {
       {
         mode: GameMode.AI,
         cardDescription: 'Play TicTacToe against the computer for free!',
+        extraInfo: { type: 'dropdown', options: ['Easy', 'Hard'] } as IGameModeExtraInfoDropdown,
       },
       {
         mode: GameMode.LocalFriend,

--- a/src/games/tictactoe/ai.test.ts
+++ b/src/games/tictactoe/ai.test.ts
@@ -3,7 +3,21 @@ import { expect } from 'chai';
 import { TictactoeGame } from './game';
 import { Client } from '@freeboardgame.org/boardgame.io/client';
 
-test('Hard - should return a move for the initial position', async () => {
+test('Easy AI - should return a move for the initial position', async () => {
+  const client = Client({
+    game: TictactoeGame,
+    ai: AIConfig.bgioAI('Easy'),
+  });
+  client.moves.clickCell(0);  // player plays
+  await client.step();  // AI plays
+  const { G, ctx } = client.store.getState();
+  const player0Moves = G.cells.filter((cell: string) => cell === '0');
+  const player1Moves = G.cells.filter((cell: string) => cell === '1');
+  expect(player0Moves.length).to.equal(1);
+  expect(player1Moves.length).to.equal(1);
+});
+
+test('Hard AI - should return a move for the initial position', async () => {
   const client = Client({
     game: TictactoeGame,
     ai: AIConfig.bgioAI('Hard'),

--- a/src/games/tictactoe/ai.test.ts
+++ b/src/games/tictactoe/ai.test.ts
@@ -6,7 +6,7 @@ import { Client } from '@freeboardgame.org/boardgame.io/client';
 test('Easy AI - should return a move for the initial position', async () => {
   const client = Client({
     game: TictactoeGame,
-    ai: AIConfig.bgioAI('Easy'),
+    ai: AIConfig.bgioAI('1'),
   });
   client.moves.clickCell(0);  // player plays
   await client.step();  // AI plays
@@ -20,7 +20,7 @@ test('Easy AI - should return a move for the initial position', async () => {
 test('Hard AI - should return a move for the initial position', async () => {
   const client = Client({
     game: TictactoeGame,
-    ai: AIConfig.bgioAI('Hard'),
+    ai: AIConfig.bgioAI('2'),
   });
   client.moves.clickCell(0);  // player plays
   await client.step();  // AI plays

--- a/src/games/tictactoe/ai.test.ts
+++ b/src/games/tictactoe/ai.test.ts
@@ -3,10 +3,10 @@ import { expect } from 'chai';
 import { TictactoeGame } from './game';
 import { Client } from '@freeboardgame.org/boardgame.io/client';
 
-test('should return a move for the initial position', async () => {
+test('Hard - should return a move for the initial position', async () => {
   const client = Client({
     game: TictactoeGame,
-    ai: AIConfig.bgioAI('1'),
+    ai: AIConfig.bgioAI('Hard'),
   });
   client.moves.clickCell(0);  // player plays
   await client.step();  // AI plays

--- a/src/games/tictactoe/ai.ts
+++ b/src/games/tictactoe/ai.ts
@@ -6,19 +6,45 @@ interface IPlayState {
   ctx: any;
 }
 
+class TictactoeBot {
+  async play(state: IPlayState, playerID: string) {
+    const cell = this.generateMove(state);
+    return this.makeMove(cell);
+  }
+  generateMove(state: IPlayState) {
+    while (true) {
+      const cell = this.randomNumber(0, 9);
+      if (state.G.cells[cell] === null) {  // unplayed
+        return cell;
+      }
+    }
+  }
+  makeMove(cell: number) {
+    return { action: { type: 'MAKE_MOVE', payload: { type: 'clickCell', args: [cell], playerID: '1' } } };
+  }
+  randomNumber(min: number, max: number) {
+    return Math.floor(Math.random() * (max - min + 1) + min);
+  }
+}
 const config: IAIConfig = {
   bgioAI: (level: string) => {
-    return AI({
-      enumerate: (G: any, ctx: any) => {
-        const moves = [];
-        for (let i = 0; i < 9; i++) {
-          if (G.cells[i] === null) {
-            moves.push({ move: 'clickCell', args: [i] });
+    if (level === 'Hard') {
+      return AI({
+        enumerate: (G: any, ctx: any) => {
+          const moves = [];
+          for (let i = 0; i < 9; i++) {
+            if (G.cells[i] === null) {
+              moves.push({ move: 'clickCell', args: [i] });
+            }
           }
-        }
-        return moves;
-      },
-    });
+          return moves;
+        },
+      });
+    } else if (level === 'Easy') {
+      return {
+        bot: TictactoeBot,
+      };
+    }
   },
 };
 export default config;

--- a/src/games/tictactoe/ai.ts
+++ b/src/games/tictactoe/ai.ts
@@ -6,7 +6,7 @@ interface IPlayState {
   ctx: any;
 }
 
-class TictactoeBot {
+class TictactoeRandomBot {
   async play(state: IPlayState, playerID: string) {
     const cell = this.generateMove(state);
     return this.makeMove(cell);
@@ -28,7 +28,7 @@ class TictactoeBot {
 }
 const config: IAIConfig = {
   bgioAI: (level: string) => {
-    if (level === 'Hard') {
+    if (level === '2') {  // Hard
       return AI({
         enumerate: (G: any, ctx: any) => {
           const moves = [];
@@ -40,9 +40,9 @@ const config: IAIConfig = {
           return moves;
         },
       });
-    } else if (level === 'Easy') {
+    } else if (level === '1') {  // Easy
       return {
-        bot: TictactoeBot,
+        bot: TictactoeRandomBot,
       };
     }
   },

--- a/src/games/tictactoe/ai.ts
+++ b/src/games/tictactoe/ai.ts
@@ -8,10 +8,10 @@ interface IPlayState {
 
 class TictactoeRandomBot {
   async play(state: IPlayState, playerID: string) {
-    const cell = this.generateMove(state);
+    const cell = this.generateRandomMove(state);
     return this.makeMove(cell);
   }
-  generateMove(state: IPlayState) {
+  generateRandomMove(state: IPlayState) {
     while (true) {
       const cell = this.randomNumber(0, 9);
       if (state.G.cells[cell] === null) {  // unplayed

--- a/src/games/tictactoe/config.ts
+++ b/src/games/tictactoe/config.ts
@@ -6,6 +6,7 @@ import { applyMiddleware } from 'redux';
 const config: IGameConfig = {
   bgioGame: TictactoeGame,
   bgioBoard: Board,
+  debug: true,
 };
 
 export default config;

--- a/src/games/tictactoe/config.ts
+++ b/src/games/tictactoe/config.ts
@@ -6,7 +6,6 @@ import { applyMiddleware } from 'redux';
 const config: IGameConfig = {
   bgioGame: TictactoeGame,
   bgioBoard: Board,
-  debug: true,
 };
 
 export default config;


### PR DESCRIPTION
Add easy AI to TicTacToe
---
The current AI for TicTacToe uses BGIO's MCTS, and it does not let users win.

This PR adds an easy "AI" which makes moves randomly. 

The easy AI is now the default, and the MCTS AI remains as the "hard" option.

A dropdown for selecting the difficulty was also added as IGameModeExtraInfoDropdown.