### PR TITLE
Switch back to TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+sudo: false
+language: node_js
+node_js:
+  - "stable"
+
+cache:
+  directories:
+    - node_modules
+
+install:
+  - yarn install
+
+script:
+  - yarn run lint
+  - yarn run prod:buildquietly
+  - yarn run test:coverage
+
+after_success:
+  - yarn run test:coveralls

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # FreeBoardGame.org
-[![Build Status](https://semaphoreci.com/api/v1/freeboardgame/freeboardgame-org/branches/master/badge.svg)](https://semaphoreci.com/freeboardgame/freeboardgame-org)
+[![Build Status](https://travis-ci.com/freeboardgame/FreeBoardGame.org.svg?branch=master)](https://travis-ci.com/freeboardgame/FreeBoardGame.org)
 [![Coverage Status](https://coveralls.io/repos/github/freeboardgame/FreeBoardGame.org/badge.svg)](https://coveralls.io/github/freeboardgame/FreeBoardGame.org)
 
 Mobile-First Free board games for everybody. Free as in "free beer" and as in "freedom". You are welcome to study the games, modify and contribute back to the community!


### PR DESCRIPTION
Revert "Remove .travis.yml (#151)"

Reverting back to Travis because we originally switched to Semaphore thinking there were issues with Travis (turned out to be a jest bug), and Semaphore does not pass the necessary information to Coveralls for it to leave a comment with coverage information.