### PR TITLE
Chess: Highlight squares for the last move

### DIFF
--- a/src/games/chess/board.tsx
+++ b/src/games/chess/board.tsx
@@ -126,6 +126,15 @@ export class Board extends React.Component<IBoardProps, {}> {
     for (const move of this._getMoves()) {
       result[move.to] = MOVABLE_COLOR;
     }
+    const pgnArray = this.props.G.pgn.split(' ');
+    if (pgnArray.length > 0) {
+      const lastMove = pgnArray[pgnArray.length - 1];
+      if (lastMove !== '') {
+        if (this.props.ctx.currentPlayer === this.props.playerID) {
+          result[lastMove] = MOVABLE_COLOR;
+        }
+      }
+    }
     return result;
   }
 

--- a/src/games/chess/board.tsx
+++ b/src/games/chess/board.tsx
@@ -26,8 +26,7 @@ import ReactGA from 'react-ga';
 const COL_NAMES = 'abcdefgh';
 const SELECTED_COLOR = 'green';
 const MOVABLE_COLOR = 'palegreen';
-const MOVE_FROM_COLOR = 'tomato';
-const MOVE_TO_COLOR = 'lightskyblue';
+const MOVED_COLOR = '#CCE5FF';
 
 interface IBoardProps {
   G: any;
@@ -122,19 +121,19 @@ export class Board extends React.Component<IBoardProps, {}> {
 
   _getHighlightedSquares() {
     const result = {} as IColorMap;
+    const history = this._fixHistory(this.chess.history({ verbose: true }));
+    if (history.length > 0) {
+      const lastMove = history[history.length - 1];
+      if (this._getCurrentPlayer() !== lastMove.color) {
+        result[lastMove.from] = MOVED_COLOR;
+        result[lastMove.to] = MOVED_COLOR;
+      }
+    }
     if (this.state.selected) {
       result[this.state.selected] = SELECTED_COLOR;
     }
     for (const move of this._getMoves()) {
       result[move.to] = MOVABLE_COLOR;
-    }
-    const history = this._fixHistory(this.chess.history({ verbose: true }));
-    if (history.length > 0) {
-      const lastMove = history[history.length - 1];
-      if (this._getCurrentPlayer() !== lastMove.color) {
-        result[lastMove.from] = MOVE_FROM_COLOR;
-        result[lastMove.to] = MOVE_TO_COLOR;
-      }
     }
     return result;
   }

--- a/src/games/chess/board.tsx
+++ b/src/games/chess/board.tsx
@@ -26,6 +26,8 @@ import ReactGA from 'react-ga';
 const COL_NAMES = 'abcdefgh';
 const SELECTED_COLOR = 'green';
 const MOVABLE_COLOR = 'palegreen';
+const MOVE_FROM_COLOR = 'tomato';
+const MOVE_TO_COLOR = 'lightskyblue';
 
 interface IBoardProps {
   G: any;
@@ -126,13 +128,12 @@ export class Board extends React.Component<IBoardProps, {}> {
     for (const move of this._getMoves()) {
       result[move.to] = MOVABLE_COLOR;
     }
-    const pgnArray = this.props.G.pgn.split(' ');
-    if (pgnArray.length > 0) {
-      const lastMove = pgnArray[pgnArray.length - 1];
-      if (lastMove !== '') {
-        if (this.props.ctx.currentPlayer === this.props.playerID) {
-          result[lastMove] = MOVABLE_COLOR;
-        }
+    const history = this._fixHistory(this.chess.history({ verbose: true }));
+    if (history.length > 0) {
+      const lastMove = history[history.length - 1];
+      if (this._getCurrentPlayer() !== lastMove.color) {
+        result[lastMove.from] = MOVE_FROM_COLOR;
+        result[lastMove.to] = MOVE_TO_COLOR;
       }
     }
     return result;


### PR DESCRIPTION
Chess: Highlight squares for the last move (closes #55)

@flamecoals, this works in multiplayer mode but does not work well with AI.  I suspect that async is the problem, can you help?  Also, what color should we make the highlighted square?

![image](https://user-images.githubusercontent.com/304383/55283765-034a8480-5338-11e9-8e61-10f8ed753f02.png)

