### PR TITLE
Use meta noindex tag instead of robots.txt

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -2,14 +2,15 @@
 <html lang="en">
   <head>
     <title>FreeBoardGame.org</title>
-    <meta name="Description" content="">
     <link rel="manifest" href="/manifest.json">
-	  <meta name="mobile-web-app-capable" content="yes">
-	  <meta name="apple-mobile-web-app-capable" content="yes">
-	  <meta name="application-name" content="FreeBoardGame.org">
-	  <meta name="apple-mobile-web-app-title" content="FreeBoardGame.org">
-	  <meta name="theme-color" content="#3f51b5"/>
-	  <meta name="viewport" content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no'>
+    <meta name="description" content="">
+    <meta name="robots" content="noindex">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="application-name" content="FreeBoardGame.org">
+    <meta name="apple-mobile-web-app-title" content="FreeBoardGame.org">
+    <meta name="theme-color" content="#3f51b5"/>
+    <meta name="viewport" content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no'>
 
     <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png">
@@ -19,7 +20,7 @@
     <link rel="shortcut icon" href="/icons/favicon.ico">
     <meta name="msapplication-TileColor" content="#ffc40d">
     <meta name="msapplication-config" content="/icons/browserconfig.xml">
-	  <meta charset="utf-8">
+    <meta charset="utf-8">
     <style>
       /* TODO: FIGURE OUT CSS AND WEBPACK AND TS. */
       html, body {

--- a/src/metadata.test.ts
+++ b/src/metadata.test.ts
@@ -23,12 +23,17 @@ describe('Metadata', () => {
     metadata = getPageMetadata('/g/chess/local');
     expect(metadata.title).to.contain(TITLE_PREFIX);
     expect(metadata.title).to.contain('Locally');
-    expect(metadata.description).to.contain('same device');
+    expect(metadata.noindex).to.equal(true);
 
     metadata = getPageMetadata('/g/chess/online');
     expect(metadata.title).to.contain(TITLE_PREFIX);
     expect(metadata.title).to.contain('Online Friend');
-    expect(metadata.description).to.contain('online friend');
+    expect(metadata.noindex).to.equal(true);
+
+    metadata = getPageMetadata('/g/chess/ai');
+    expect(metadata.title).to.contain(TITLE_PREFIX);
+    expect(metadata.title).to.contain('the Computer');
+    expect(metadata.noindex).to.equal(true);
 
     metadata = getPageMetadata('/g/seabattle');
     expect(metadata.title).to.contain(TITLE_PREFIX);
@@ -38,7 +43,12 @@ describe('Metadata', () => {
     metadata = getPageMetadata('/g/seabattle/online');
     expect(metadata.title).to.contain(TITLE_PREFIX);
     expect(metadata.title).to.contain('Online Friend');
-    expect(metadata.description).to.contain('online friend');
+    expect(metadata.noindex).to.equal(true);
+
+    metadata = getPageMetadata('/g/seabattle/ai');
+    expect(metadata.title).to.contain(TITLE_PREFIX);
+    expect(metadata.title).to.contain('the Computer');
+    expect(metadata.noindex).to.equal(true);
 
     metadata = getPageMetadata('/g/tictactoe');
     expect(metadata.title).to.contain(TITLE_PREFIX);
@@ -48,12 +58,17 @@ describe('Metadata', () => {
     metadata = getPageMetadata('/g/tictactoe/local');
     expect(metadata.title).to.contain(TITLE_PREFIX);
     expect(metadata.title).to.contain('Locally');
-    expect(metadata.description).to.contain('same device');
+    expect(metadata.noindex).to.equal(true);
 
     metadata = getPageMetadata('/g/tictactoe/online');
     expect(metadata.title).to.contain(TITLE_PREFIX);
     expect(metadata.title).to.contain('Online Friend');
-    expect(metadata.description).to.contain('online friend');
+    expect(metadata.noindex).to.equal(true);
+
+    metadata = getPageMetadata('/g/tictactoe/ai');
+    expect(metadata.title).to.contain(TITLE_PREFIX);
+    expect(metadata.title).to.contain('the Computer');
+    expect(metadata.noindex).to.equal(true);
 
     metadata = getPageMetadata('/about');
     expect(metadata.title).to.contain(TITLE_PREFIX);

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -1,6 +1,8 @@
 export interface IPageMetadata {
-  title: string; description: string;
+  title: string;
+  description?: string;
   url?: RegExp;
+  noindex?: boolean;
 }
 
 const TITLE_PREFIX = 'FreeBoardGame.org - ';
@@ -14,13 +16,19 @@ Compete against your online friends or play locally. Free and open-source softwa
 // Most specific URLs MUST come first.
 const PAGES_METADATA: IPageMetadata[] = [
   {
+    title: TITLE_PREFIX + 'Play Chess Against the Computer',
+    noindex: true,
+    url: new RegExp('^/g/chess/ai', 'i'),
+  },
+  {
     title: TITLE_PREFIX + 'Play Two Player Chess Locally',
-    description: 'Play a free chess game in your browser for two players sharing the same device.',
+    noindex: true,
     url: new RegExp('^/g/chess/local', 'i'),
   },
   {
     title: TITLE_PREFIX + 'Play Chess with an Online Friend',
     description: 'Play a free chess game against an online friend in your browser.',
+    noindex: true,
     url: new RegExp('^/g/chess/online', 'i'),
   },
   {
@@ -29,13 +37,18 @@ const PAGES_METADATA: IPageMetadata[] = [
     url: new RegExp('^/g/chess', 'i'),
   },
   {
+    title: TITLE_PREFIX + 'Play Free Tic-Tac-Toe Against the Computer',
+    noindex: true,
+    url: new RegExp('^/g/tictactoe/ai', 'i'),
+  },
+  {
     title: TITLE_PREFIX + 'Play Free Tic-Tac-Toe with Online Friend',
-    description: 'Play a free game of Tic-Tac-Toe in your browser.  Compete against your online friends.',
+    noindex: true,
     url: new RegExp('^/g/tictactoe/online', 'i'),
   },
   {
     title: TITLE_PREFIX + 'Play Free Tic-Tac-Toe Locally',
-    description: 'Play a free game of Tic-Tac-Toe in your browser for two players sharing the same device.',
+    noindex: true,
     url: new RegExp('^/g/tictactoe/local', 'i'),
   },
   {
@@ -44,8 +57,14 @@ const PAGES_METADATA: IPageMetadata[] = [
     url: new RegExp('^/g/tictactoe', 'i'),
   },
   {
+    title: TITLE_PREFIX + 'Play Free Seabattle Against the Computer',
+    noindex: true,
+    url: new RegExp('^/g/seabattle/ai', 'i'),
+  },
+  {
     title: TITLE_PREFIX + 'Play Free Seabattle with Online Friend',
     description: 'Battle and sink ships in a free online game with an online friend.',
+    noindex: true,
     url: new RegExp('^/g/seabattle/online', 'i'),
   },
   {

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -36,16 +36,16 @@ function renderHtml(layout: string, metadata: IPageMetadata, reactHtml: string) 
 
   if (metadata.description) {
     result = result.replace(
-      '    <meta name="description" content="">\n',
-      `    <meta name="description" content="${metadata.description}">\n`);
+      '<meta name="description" content="">\n',
+      `<meta name="description" content="${metadata.description}">\n`);
   } else {
     result = result.replace(
-      '    <meta name="description" content="">\n',
+      '<meta name="description" content="">\n',
       '');
   }
 
   if (!metadata.noindex) {
-    result = result.replace('   <meta name="robots" content="noindex">\n',
+    result = result.replace('<meta name="robots" content="noindex">\n',
       '');
   }
 

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -12,7 +12,7 @@ import serialize from 'serialize-javascript';
 import { StaticRouter } from 'react-router-dom';
 import { GAMES_LIST } from './games';
 import { GameMode } from './App/Game/GameModePicker';
-import { getPageMetadata } from './metadata';
+import { getPageMetadata, IPageMetadata } from './metadata';
 import noCache from 'koa-no-cache';
 
 const { Server } = require('@freeboardgame.org/boardgame.io/server'); // tslint:disable-line
@@ -27,16 +27,28 @@ const DEV = !PROD;
 const RESTRICTIVE_ROBOTS_TXT = ['User-agent: *',
   'Disallow: /', ''].join('\n');
 
-const OPEN_ROBOTS_TXT = getOpenRobotsTxt();
-
 const template = fs.readFileSync('./dist/layout.html', 'utf8');
 
-function renderHtml(layout: string, title: string, description: string, reactHtml: string) {
+function renderHtml(layout: string, metadata: IPageMetadata, reactHtml: string) {
   let result = layout;
-  result = result.replace('<title>FreeBoardGame.org</title>', `<title>${title}</title>`);
-  result = result.replace(
-    '<meta name="Description" content="">',
-    `<meta name="Description" content="${description}">`);
+
+  result = result.replace('<title>FreeBoardGame.org</title>', `<title>${metadata.title}</title>`);
+
+  if (metadata.description) {
+    result = result.replace(
+      '    <meta name="description" content="">\n',
+      `    <meta name="description" content="${metadata.description}">\n`);
+  } else {
+    result = result.replace(
+      '    <meta name="description" content="">\n',
+      '');
+  }
+
+  if (!metadata.noindex) {
+    result = result.replace('   <meta name="robots" content="noindex">\n',
+      '');
+  }
+
   result = result.replace(
     '<div id="root"></div>',
     `<div id="root">${reactHtml}</div>`);
@@ -63,7 +75,7 @@ const renderSite = async (url: string) => {
   const reactHtml = ReactDOMServer.renderToStaticMarkup(app);
   return ({
     status: (context as any).status,
-    render: renderHtml(template, title, description, reactHtml),
+    render: renderHtml(template, metadata, reactHtml),
   });
 };
 
@@ -79,9 +91,7 @@ const startServer = async () => {
   server.app.use(router.allowedMethods());
   server.app.use(async (ctx: any, next: any) => {
     if (ctx.request.path === '/robots.txt') {
-      if (ctx.request.hostname.toLowerCase() === 'freeboardgame.org') {
-        ctx.response.body = OPEN_ROBOTS_TXT;
-      } else {
+      if (ctx.request.hostname.toLowerCase() !== 'freeboardgame.org') {
         ctx.response.body = RESTRICTIVE_ROBOTS_TXT;
       }
     } else {
@@ -101,23 +111,5 @@ const startServer = async () => {
     console.log(`Serving ${NODE_ENV} at: http://${HOST}:${PORT}/`); // tslint:disable-line
   });
 };
-
-function getOpenRobotsTxt() {
-  const robotsTxt = ['User-agent: *'];
-  const AI = GameMode.AI;
-  const OnlineFriend = GameMode.OnlineFriend;
-  GAMES_LIST.forEach((game) => {
-    game.modes.forEach((modeInfo) => {
-      if (modeInfo.mode === GameMode.AI) {
-        robotsTxt.push(`Disallow: /g/${game.code}/AI/`);
-      }
-      if (modeInfo.mode === GameMode.OnlineFriend) {
-        robotsTxt.push(`Disallow: /g/${game.code}/online/`);
-      }
-    });
-  });
-  robotsTxt.push('');  // so that there is a newline at the end of the file
-  return robotsTxt.join('\n');
-}
 
 startServer();


### PR DESCRIPTION
Use meta noindex tag instead of robots.txt

https://support.google.com/webmasters/answer/93710?hl=en

If running on freeboardgame.org, return 404 for /robots.txt, else, return a restrictive robots.txt

Closes #192 