### PR TITLE
Fix appbar -- now link is only surrounding the FBG logo / text.

### DIFF
--- a/src/App/Game/GameDarkSublayout.tsx
+++ b/src/App/Game/GameDarkSublayout.tsx
@@ -36,7 +36,7 @@ export class GameDarkSublayout extends React.Component<IGameDarkSublayoutProps, 
               marginRight: 'auto',
             }}
           >
-            <Link to="/" style={{ textDecoration: 'none' }}>
+            <Link to="/" style={{ float: 'left', textDecoration: 'none' }}>
               <img
                 src={FbgLogo}
                 alt="FreeBoardGame.org"
@@ -45,7 +45,7 @@ export class GameDarkSublayout extends React.Component<IGameDarkSublayoutProps, 
               <Typography
                 variant="title"
                 gutterBottom={true}
-                style={{ paddingTop: '14px', color: 'white' }}
+                style={{ float: 'left', paddingTop: '14px', color: 'white' }}
               >
                 FreeBoardGame.org
               </Typography>


### PR DESCRIPTION
Before the homepage link was large and had 100% width (red).  Now it only surrounds the FBG logo / text.  This fixes the BGIO debugging tools and will also help me implement #195.

![Screenshot from 2019-04-26 13-01-00](https://user-images.githubusercontent.com/304383/56833807-6d195980-6824-11e9-9541-e6aac682e9ed.png)
