### PR TITLE
Fix 'Not implemented: HTMLMediaElement ...' warnings when running tests

### DIFF
--- a/src/games/seabattle/Battle.test.tsx
+++ b/src/games/seabattle/Battle.test.tsx
@@ -7,6 +7,13 @@ import { IShip, ISeabattleState, SeabattleGame } from './game';
 import { VALID_SETUP_FIRST_PLAYER, VALID_SETUP_SECOND_PLAYER } from './mocks';
 import { Client } from '@freeboardgame.org/boardgame.io/client';
 
+// mock functions for HTMLMediaElement
+// https://github.com/jsdom/jsdom/issues/2155#issuecomment-366703395
+(window as any).HTMLMediaElement.prototype.load = () => { /* do nothing */ };
+(window as any).HTMLMediaElement.prototype.play = () => { /* do nothing */ };
+(window as any).HTMLMediaElement.prototype.pause = () => { /* do nothing */ };
+(window as any).HTMLMediaElement.prototype.addTextTrack = () => { /* do nothing */ };
+
 Enzyme.configure({ adapter: new Adapter() });
 
 test('one phase - hit', () => {


### PR DESCRIPTION
Fix 'Not implemented: HTMLMediaElement ...' warnings when running tests