### PR TITLE
Switch to ts-easy-i18n

### DIFF
--- a/@types/react-easy-i18n/index.d.ts
+++ b/@types/react-easy-i18n/index.d.ts
@@ -1,1 +1,0 @@
-declare module 'react-easy-i18n';

--- a/@types/ts-easy-i18n/index.d.ts
+++ b/@types/ts-easy-i18n/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'ts-easy-i18n';

--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
     "react-async-bootstrapper": "^2.1.1",
     "react-async-component": "^2.0.0",
     "react-dom": "^16.7.0",
-    "react-easy-i18n": "^0.3.1",
     "react-ga": "^2.5.7",
     "react-router-dom": "^4.2.2",
     "rrc": "^0.10.1",
@@ -131,6 +130,7 @@
     "shuffle-array": "^1.0.1",
     "socket.io-client": "^2.2.0",
     "three": "^0.101.1",
+    "ts-easy-i18n": "^0.2.3",
     "webpack-shell-plugin-next": "^0.6.4",
     "workbox-sw": "^3.6.3",
     "workbox-webpack-plugin": "^3.6.3"

--- a/src/About/About.tsx
+++ b/src/About/About.tsx
@@ -7,7 +7,7 @@ import ListItemText from '@material-ui/core/ListItemText';
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
 import Typography from '@material-ui/core/Typography';
-import { Text } from 'react-easy-i18n';
+import { trans } from 'ts-easy-i18n';
 
 class About extends React.Component<{}, {}> {
   render() {
@@ -25,7 +25,7 @@ class About extends React.Component<{}, {}> {
       <Card style={{ marginTop: '16px' }}>
         <CardContent>
           <Typography variant="h5" component="h2">
-            <Text text="about.header" />
+            {trans('about.header')}
           </Typography>
           <Typography component="p">
             FreeBoardGame.org is a free (as in freedom), mobile-first, board game platform.

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -7,7 +7,7 @@ import About from '../About/AboutAsync';
 import getMessagePage from './MessagePage';
 import ReactGA from 'react-ga';
 import { getPageMetadata } from '../metadata';
-import { registerLang, setCurrentLocale, Text } from 'react-easy-i18n';
+import { registerLang, setCurrentLocale } from 'ts-easy-i18n';
 import translations from './translations';
 
 ReactGA.initialize('UA-105391878-1');

--- a/src/App/MessagePageClass.tsx
+++ b/src/App/MessagePageClass.tsx
@@ -6,7 +6,7 @@ import FreeBoardGameBar from './FreeBoardGameBar';
 import SvgError from './media/SvgError';
 import Typography from '@material-ui/core/Typography';
 import { Status } from 'rrc';
-import { Text } from 'react-easy-i18n';
+import { trans } from 'ts-easy-i18n';
 
 interface IMessageState {
   linkHidden: boolean;
@@ -56,7 +56,7 @@ export class MessagePage extends React.Component<IMessageProps, IMessageState> {
       linkHome = (
         <Button href="/" variant="outlined" style={{ margin: '8px' }}>
           <HomeIcon style={{ marginRight: '8px' }} />
-          <Text text="messagePage.goHome" />
+          {trans('messagePage.goHome')}
         </Button>);
     }
     return (

--- a/test/test-setup.js
+++ b/test/test-setup.js
@@ -13,9 +13,9 @@ enzyme.configure({ adapter: new Adapter() });
 jest.mock('react-ga');
 
 // mock i18n
-// <Text text="examplepage.header" /> will render in tests as "examplepage.header"
-jest.mock('react-easy-i18n', () => ({
-  Text: jest.fn(attr => attr.text),
+// trans('examplepage.header') will render in tests as "examplepage.header"
+jest.mock('ts-easy-i18n', () => ({
+  trans: jest.fn(attr => attr),
   registerLang: jest.fn(),
   setCurrentLocale: jest.fn()
 }))

--- a/yarn.lock
+++ b/yarn.lock
@@ -1508,22 +1508,6 @@ after@0.8.2:
   resolved "https://registry.yarnpkg.com/after/-/after-0.8.2.tgz#fedb394f9f0e02aa9768e702bda23b505fae7e1f"
   integrity sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=
 
-airbnb-prop-types@^2.13.2:
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/airbnb-prop-types/-/airbnb-prop-types-2.13.2.tgz#43147a5062dd2a4a5600e748a47b64004cc5f7fc"
-  integrity sha512-2FN6DlHr6JCSxPPi25EnqGaXC4OC3/B3k1lCd6MMYrZ51/Gf/1qDfaR+JElzWa+Tl7cY2aYOlsYJGFeQyVHIeQ==
-  dependencies:
-    array.prototype.find "^2.0.4"
-    function.prototype.name "^1.1.0"
-    has "^1.0.3"
-    is-regex "^1.0.4"
-    object-is "^1.0.1"
-    object.assign "^4.1.0"
-    object.entries "^1.1.0"
-    prop-types "^15.7.2"
-    prop-types-exact "^1.2.0"
-    react-is "^16.8.6"
-
 ajv-errors@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
@@ -1667,14 +1651,6 @@ array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
-
-array.prototype.find@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/array.prototype.find/-/array.prototype.find-2.0.4.tgz#556a5c5362c08648323ddaeb9de9d14bc1864c90"
-  integrity sha1-VWpcU2LAhkgyPdrrnenRS8GGTJA=
-  dependencies:
-    define-properties "^1.1.2"
-    es-abstract "^1.7.0"
 
 array.prototype.flat@^1.2.1:
   version "1.2.1"
@@ -3262,17 +3238,6 @@ entities@^1.1.1, entities@~1.1.1:
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
   integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
 
-enzyme-adapter-react-15@^1.0.5:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-15/-/enzyme-adapter-react-15-1.4.0.tgz#4abd648205a8f25f88beedb8f431dc4809eb45a4"
-  integrity sha512-PHLE4JzUUDhk9RpoLb0MPVaGhVe2i/nowVjzPhbk6cL8rqOHegh/KMOVlndelf3GBZfp0axl2C9OCbYhrSBtqg==
-  dependencies:
-    enzyme-adapter-utils "^1.10.1"
-    object.assign "^4.1.0"
-    object.values "^1.1.0"
-    prop-types "^15.7.2"
-    react-is "^16.8.6"
-
 enzyme-adapter-react-16@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.8.0.tgz#7055d8e908d8d27b807cf4292244db3c815ca11d"
@@ -3295,18 +3260,6 @@ enzyme-adapter-utils@^1.10.0:
     object.assign "^4.1.0"
     object.fromentries "^2.0.0"
     prop-types "^15.6.2"
-    semver "^5.6.0"
-
-enzyme-adapter-utils@^1.10.1:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/enzyme-adapter-utils/-/enzyme-adapter-utils-1.12.0.tgz#96e3730d76b872f593e54ce1c51fa3a451422d93"
-  integrity sha512-wkZvE0VxcFx/8ZsBw0iAbk3gR1d9hK447ebnSYBf95+r32ezBq+XDSAvRErkc4LZosgH8J7et7H7/7CtUuQfBA==
-  dependencies:
-    airbnb-prop-types "^2.13.2"
-    function.prototype.name "^1.1.0"
-    object.assign "^4.1.0"
-    object.fromentries "^2.0.0"
-    prop-types "^15.7.2"
     semver "^5.6.0"
 
 enzyme@^3.8.0:
@@ -3353,7 +3306,7 @@ error-inject@^1.0.0:
   resolved "https://registry.yarnpkg.com/error-inject/-/error-inject-1.0.0.tgz#e2b3d91b54aed672f309d950d154850fa11d4f37"
   integrity sha1-4rPZG1Su1nLzCdlQ0VSFD6EdTzc=
 
-es-abstract@^1.10.0, es-abstract@^1.11.0, es-abstract@^1.12.0, es-abstract@^1.4.3, es-abstract@^1.5.0, es-abstract@^1.5.1, es-abstract@^1.7.0:
+es-abstract@^1.10.0, es-abstract@^1.11.0, es-abstract@^1.12.0, es-abstract@^1.4.3, es-abstract@^1.5.0, es-abstract@^1.5.1:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.13.0.tgz#ac86145fdd5099d8dd49558ccba2eaf9b88e24e9"
   integrity sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==
@@ -6305,7 +6258,7 @@ object.assign@^4.1.0:
     has-symbols "^1.0.0"
     object-keys "^1.0.11"
 
-object.entries@^1.0.4, object.entries@^1.1.0:
+object.entries@^1.0.4:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.0.tgz#2024fc6d6ba246aee38bdb0ffd5cfbcf371b7519"
   integrity sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==
@@ -6854,15 +6807,6 @@ prompts@^2.0.1:
     kleur "^3.0.2"
     sisteransi "^1.0.0"
 
-prop-types-exact@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/prop-types-exact/-/prop-types-exact-1.2.0.tgz#825d6be46094663848237e3925a98c6e944e9869"
-  integrity sha512-K+Tk3Kd9V0odiXFP9fwDHUYRyvK3Nun3GVyPapSIs5OBkITAm15W0CPFD/YKTkMUAbc0b9CUwRQp2ybiBIq+eA==
-  dependencies:
-    has "^1.0.3"
-    object.assign "^4.1.0"
-    reflect.ownkeys "^0.2.0"
-
 prop-types@^15.5.10, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
@@ -6871,7 +6815,7 @@ prop-types@^15.5.10, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-prop-types@^15.5.8, prop-types@^15.7.2:
+prop-types@^15.5.8:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -7047,16 +6991,6 @@ react-cookies@^0.1.0:
     cookie "^0.3.1"
     object-assign "^4.1.1"
 
-react-dom@^15.6.1:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.2.tgz#41cfadf693b757faf2708443a1d1fd5a02bef730"
-  integrity sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.10"
-
 react-dom@^16.7.0:
   version "16.7.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.7.0.tgz#a17b2a7ca89ee7390bc1ed5eb81783c7461748b8"
@@ -7073,16 +7007,6 @@ react-dragtastic@^2.4.3:
   integrity sha512-AQwmi3Ri9/Fpf8FKabxnsxSh6gRYZHIQqRBubu3NSBvWQ7bOOpqGxlTtxZVkj3QiSg3h2S3xYZoxB27A6dV0xg==
   dependencies:
     prop-types "^15.6.0"
-
-react-easy-i18n@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/react-easy-i18n/-/react-easy-i18n-0.3.1.tgz#2af38da13b90df32ea7e14ea7899c61c38c44c92"
-  integrity sha512-Pgmd9vWiDsFTMVfHV3OIrc2tzqeUQsoncy/mkvTFnaq+8sx1YwiK8m/lRJnF7spMVb2TkN70tMs6L9iQ7HwQbA==
-  dependencies:
-    enzyme-adapter-react-15 "^1.0.5"
-    react "^15.6.1"
-    react-dom "^15.6.1"
-    ts-easy-i18n "^0.2.2"
 
 react-event-listener@^0.6.2:
   version "0.6.6"
@@ -7113,7 +7037,7 @@ react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.3.tgz#4ad8b029c2a718fc0cfc746c8d4e1b7221e5387d"
   integrity sha512-Y4rC1ZJmsxxkkPuMLwvKvlL1Zfpbcu+Bf4ZigkHup3v9EfdYhAlWAaVyA19olXq2o2mGn0w+dFKvk3pVVlYcIA==
 
-react-is@^16.8.4, react-is@^16.8.6:
+react-is@^16.8.4:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
@@ -7173,7 +7097,7 @@ react-tree-walker@^4.2.0:
   resolved "https://registry.yarnpkg.com/react-tree-walker/-/react-tree-walker-4.3.0.tgz#b7cae498cebb490281e9e99a01bdb9c6b4926cd3"
   integrity sha512-sO/pk+JQ2mbtPGdlKbeeo2aT4qXl5nPkGVO96yYQOdX9jYvRNXSnMWIydniLVEoiPvUbpfoc057blGbAQgMBRg==
 
-react@^15.5.4, react@^15.6.1:
+react@^15.5.4:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/react/-/react-15.6.2.tgz#dba0434ab439cfe82f108f0f511663908179aa72"
   integrity sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=
@@ -7292,11 +7216,6 @@ referrer-policy@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/referrer-policy/-/referrer-policy-1.1.0.tgz#35774eb735bf50fb6c078e83334b472350207d79"
   integrity sha1-NXdOtzW/UPtsB46DM0tHI1AgfXk=
-
-reflect.ownkeys@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz#749aceec7f3fdf8b63f927a04809e90c5c0b3460"
-  integrity sha1-dJrO7H8/34tj+SegSAnpDFwLNGA=
 
 regenerate-unicode-properties@^7.0.0:
   version "7.0.0"
@@ -8455,7 +8374,7 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
-ts-easy-i18n@^0.2.2:
+ts-easy-i18n@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/ts-easy-i18n/-/ts-easy-i18n-0.2.3.tgz#a7947820c368ba4cbb019af65dfe2eabbf2c261e"
   integrity sha512-Q+g0fFpFWSXV5YKtCSRKzaxNd4ZY/pUyTm5je6wgAepPgPYFaqz3Wfxwy/BeZ9VdFCLY1e9lt0a1PmmMLTj19g==


### PR DESCRIPTION
Switch to ts-easy-i18n

I don't like the idea of using react-easy-i18n's <Text> components.  It can sometimes make things (like passing translations to components) tricky. 

Instead we can now use ```{ trans('home.header') }```  :-)  