### PR TITLE
Fix 'Not implemented: window.scrollTo' warning in tests

### DIFF
--- a/test/test-setup.js
+++ b/test/test-setup.js
@@ -25,6 +25,9 @@ jest.mock('copy-to-clipboard', () => {
   return global.copyClipboardMock;
 });
 
+// mock window.scrollTo
+global.scrollTo = jest.fn();
+
 //SW mock
 if (typeof window !== 'undefined') {
   let swRegisterMock = jest.fn();


### PR DESCRIPTION
Fix 'Not implemented: window.scrollTo' warning in tests