### PR TITLE
Fix memory leak in MessagePage

### DIFF
--- a/src/App/MessagePageClass.test.tsx
+++ b/src/App/MessagePageClass.test.tsx
@@ -52,17 +52,22 @@ test('MessagePage link is hidden', () => {
     </MemoryRouter>,
   ).find(MessagePage);
   msg.setState({ linkHidden: true, startTime: 0 });
+  (msg.find(MessagePage).instance() as MessagePage).requestID = 1;
   (msg.instance() as MessagePage)._animate(125)();
   expect(msg.html()).not.to.contain('messagePage.goHome');
 });
 
 test('MessagePage unhides link after 5 seconds', () => {
+  const context = { requestID: 1 };
   const msg = Enzyme.mount(
     <MemoryRouter>
       <MessagePage type={'loading'} message={'loading'} />
     </MemoryRouter>,
+    { context },
   ).find(MessagePage);
   msg.setState({ linkHidden: true, startTime: 0 });
+  // satisfy the if () in _animate
+  (msg.find(MessagePage).instance() as MessagePage).requestID = 1;
   (msg.find(MessagePage).instance() as MessagePage)._animate(6000)();
   expect(msg.html()).to.contain('messagePage.goHome');
 });

--- a/src/App/MessagePageClass.tsx
+++ b/src/App/MessagePageClass.tsx
@@ -19,6 +19,7 @@ interface IMessageProps {
 }
 
 export class MessagePage extends React.Component<IMessageProps, IMessageState> {
+  requestID: number = null;
   constructor(props: IMessageProps) {
     super(props);
     this.state = {
@@ -26,21 +27,30 @@ export class MessagePage extends React.Component<IMessageProps, IMessageState> {
       startTime: Date.now(),
     };
     if (typeof window !== 'undefined' && props.type !== 'error') {
-      requestAnimationFrame(this._animate(Date.now()));
+      this.requestID = window.requestAnimationFrame(this._animate(Date.now()));
     }
   }
 
   _animate = (now: number) => () => {
-    const elapsed = now - this.state.startTime;
-    const linkHidden = elapsed < 5000;
-    this.setState({
-      ...this.state,
-      linkHidden,
-    });
-    if (linkHidden) {
-      requestAnimationFrame(this._animate(Date.now()));
+    if (this.requestID) {
+      const elapsed = now - this.state.startTime;
+      const linkHidden = elapsed < 5000;
+      this.setState({
+        ...this.state,
+        linkHidden,
+      });
+      if (linkHidden) {
+        this.requestID = window.requestAnimationFrame(this._animate(Date.now()));
+      }
     }
   };
+
+  componentWillUnmount() {
+    if (this.requestID) {
+      window.cancelAnimationFrame(this.requestID);
+      this.requestID = null;
+    }
+  }
 
   render() {
     let icon;


### PR DESCRIPTION
Fixes

```Warning: Can’t call setState on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.```