### PR TITLE
Fix TS warning: Arbitrary expressions are forbidden in export assignments in ambient contexts

### DIFF
--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1,14 +1,17 @@
 declare module '*.png' {
-  export default '' as string;
+  const _default: string;
+  export default _default;
 }
 declare module '*.mp3' {
-  export default '' as string;
+  const _default: string;
+  export default _default;
 }
 declare module '*.md' {
   const content: string;
   export default content;
 }
 declare module '*.css' {
-  export default {} as any;
+  const _default: any;
+  export default _default;
 }
 declare module 'react-async-bootstrapper';


### PR DESCRIPTION
Fix TS warning: Arbitrary expressions are forbidden in export assignments in ambient contexts

https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#arbitrary-expressions-are-forbidden-in-export-assignments-in-ambient-contexts