### PR TITLE
Do not create a new room when back button is pressed on game lobby page

### DIFF
--- a/src/App/Lobby/NewRoom.test.tsx
+++ b/src/App/Lobby/NewRoom.test.tsx
@@ -9,8 +9,8 @@ require('@testing-library/jest-dom/extend-expect');
 describe('New Room', () => {
   afterEach(cleanup);
   it('should redirect', async () => {
-    const p = Promise.resolve('roomfoo');
-    LobbyService.newRoom = jest.fn().mockReturnValue(p);
+    const newRoomMock = jest.fn().mockResolvedValue('roomfoo');
+    LobbyService.newRoom = newRoomMock;
     const historyMock = jest.fn();
     const app = (
       <MemoryRouter>
@@ -19,13 +19,13 @@ describe('New Room', () => {
             params: { gameCode: 'chess', numPlayers: 2 },
           }}
           history={{
-            push: historyMock,
+            replace: historyMock,
           }}
         />
       </MemoryRouter>
     );
     mount(app);
-    await p;
+    await newRoomMock;
     expect(historyMock).toHaveBeenCalled();
   });
 

--- a/src/App/Lobby/NewRoom.tsx
+++ b/src/App/Lobby/NewRoom.tsx
@@ -10,7 +10,7 @@ interface IExpectedParams {
 
 interface INewRoomProps {
   match: { params: IExpectedParams };
-  history?: { push: (url: string) => void };
+  history?: { replace: (url: string) => void };
 }
 
 interface INewRoomState {
@@ -30,7 +30,7 @@ export class NewRoom extends React.Component<INewRoomProps, INewRoomState> {
     }
     LobbyService.newRoom(gameCode, numPlayers).then(
       roomID => {
-        this.props.history.push(`/room/${gameCode}/${roomID}`);
+        this.props.history.replace(`/room/${gameCode}/${roomID}`);
       },
       () => {
         this.setState({ error: true });


### PR DESCRIPTION
Do not create a new room when back button is pressed on game lobby page

Fixes #374 